### PR TITLE
Ignore subtags if there are none.

### DIFF
--- a/plugin.video.msnbcvideo/default.py
+++ b/plugin.video.msnbcvideo/default.py
@@ -279,10 +279,11 @@ def populateSources(slug,dataParam):
           
           videoSoup = BeautifulSoup(data, 'html.parser')
           videos = videoSoup.findAll("video")
-          subTags = videoSoup.findAll("textstream")[0]['src']
-          logging.debug(subTags)
+          subTags =''
+          if textStream:
+            subTags = videoSoup.findAll("textstream")[0]['src']
 
-          logging.debug("subs: " + subTags)
+          #logging.debug("subs: " + subTags)
           for video in videos:
             height = "0"
             src=''


### PR DESCRIPTION
Should work with the few msnbc videos that doesn't have subtags.
Small bug is that subs are 3.2 seconds ahead when they do, not sure if we can change this via kodi api's.